### PR TITLE
fix: align odometer topic config

### DIFF
--- a/config/planner.yaml
+++ b/config/planner.yaml
@@ -2,7 +2,7 @@ planner_node:
   ros__parameters:
     topics:
       lanes:         /ap1/mapping/lanes
-      odometer:      /ap1/localization/odometer
+      odometer:      /ap1/mapping/odometer
       entities:      /ap1/mapping/entities
       speed:         /ap1/actuation/speed
       state:         /ap1/planning/state


### PR DESCRIPTION
Problem
planner_node.cpp defaults the odometer subscription to /ap1/mapping/odometer, but config/planner.yaml still points topics.odometer at /ap1/localization/odometer.

This makes the checked-in config disagree with the planner default and with mapping's odometer output topic.

Changes
- Update config/planner.yaml so topics.odometer uses /ap1/mapping/odometer.

Test plan
- git diff --check
- Compared against planner_node.cpp default odometer topic.