### PR TITLE
fix: stamp planner outputs

### DIFF
--- a/src/planner_node.cpp
+++ b/src/planner_node.cpp
@@ -170,6 +170,11 @@ void PlannerNode::planning_loop_callback()
     TargetPathStamped path;
     SpeedProfileStamped speed_profile;
     frames::unwrap_route_f(route_f, path, speed_profile);
+    const auto stamp = this->now();
+    path.header.stamp = stamp;
+    path.header.frame_id = this->current_lane_->header.frame_id;
+    speed_profile.header.stamp = stamp;
+    speed_profile.header.frame_id = this->current_lane_->header.frame_id;
 
     // publish
     target_path_pub_->publish(path);


### PR DESCRIPTION
Problem
Planner publishes TargetPathStamped and SpeedProfileStamped messages with default/zero headers. During smoke testing, target_path echoed with sec: 0, nanosec: 0.

Downstream consumers and debugging tools should be able to trust the planner output timestamps/frame ids.

Changes
- Stamp TargetPathStamped before publishing.
- Stamp SpeedProfileStamped before publishing.
- Use the current lane frame_id for both output frame ids.

Test plan
- colcon build --symlink-install --packages-select ap1_planning --cmake-args -DCMAKE_BUILD_TYPE=Release
- git diff --check